### PR TITLE
Add note about other CKAN project

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ This repository has been deprecated in favour of a more centralised approach, wi
 [Click here to go to the CKAN wiki](https://github.com/KSP-CKAN/CKAN/wiki)
 
 [Click here to open a new CKAN issue](https://github.com/KSP-CKAN/CKAN/issues/new)
+
+
+---
+*Note*: Are you looking for the Open Data portal software called CKAN? If so, their GitHub repository is found at https://github.com/ckan/ckan


### PR DESCRIPTION
Hi! I'm one of the maintainers of the "other" [CKAN](http://ckan.org) project. We've found that this repo scores quite high when people google "ckan support" and some users have ended up in the wrong repo. We were wondering if you could add a small note on the README to avoid confusion? I'm happy to change the wording or the format if it doesn't work.

Thanks a lot!
